### PR TITLE
Update Accept() to return remote address

### DIFF
--- a/examples/file_receiver.go
+++ b/examples/file_receiver.go
@@ -24,7 +24,7 @@ func main() {
 	}
 
 	for {
-		s, err := a.Accept()
+		s, _, err := a.Accept()
 		if err != nil {
 			panic("Error on Accept")
 			break

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/haivision/srtgo
 
 go 1.12
+
+require golang.org/x/sys v0.0.0-20200926100807-9d91bd62050c


### PR DESCRIPTION
Changes the interface for `Accept()` to return the remote address. I wasn't able to find any other way after the connection was established to get that information.