### PR TITLE
fix non-blocking mode listening and blocking mode option parsing

### DIFF
--- a/srtgo.go
+++ b/srtgo.go
@@ -101,14 +101,17 @@ func NewSrtSocket(host string, port uint16, options map[string]string) *SrtSocke
 		s.pktSize = defaultPacketSize
 	}
 
-	val, s.blocking = options["blocking"]
-	if !s.blocking || val == "0" {
+	val, exists = options["blocking"]
+	if exists && val != "0" {
+		s.blocking = true
+	}
+	if !s.blocking {
 		s.epollConnect = C.srt_epoll_create()
 		if s.epollConnect < 0 {
 			return nil
 		}
 		var modes C.int
-		modes = C.SRT_EPOLL_OUT | C.SRT_EPOLL_ERR
+		modes = C.SRT_EPOLL_IN | C.SRT_EPOLL_OUT | C.SRT_EPOLL_ERR
 		if C.srt_epoll_add_usock(s.epollConnect, s.socket, &modes) == SRT_ERROR {
 			return nil
 		}
@@ -191,7 +194,7 @@ func (s SrtSocket) Accept() (*SrtSocket, *net.UDPAddr, error) {
 		len := C.int(2)
 		timeoutMs := C.int64_t(-1)
 		ready := [2]C.int{SRT_INVALID_SOCK, SRT_INVALID_SOCK}
-		if C.srt_epoll_wait(s.epollConnect, nil, nil, &ready[0], &len, timeoutMs, nil, nil, nil, nil) == -1 {
+		if C.srt_epoll_wait(s.epollConnect, &ready[0], &len, nil, nil, timeoutMs, nil, nil, nil, nil) == -1 {
 			return nil, nil, fmt.Errorf("srt accept, epoll wait issue")
 		}
 	}


### PR DESCRIPTION
Fixes accept in non-blocking mode and makes
```options["blocking"] = "0"``` work like it should.

Previously when the option was set to "0" s.blocking would still end up being true, so all examples are actually using blocking mode.

Non-blocking mode was only enabled if the option was not set at all which produced the error encountered in #8 when trying to listen because the epoll_wait was waiting for the wrong condition.