### PR TITLE
reword readme a bit, add close calls to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 Go bindings for [SRT](https://github.com/Haivision/srt) (Secure Reliable Transport), the open source transport technology that optimizes streaming performance across unpredictable networks.
 
 ## Why srtgo?
-To make easier the adoption of SRT transport technology. Using Go, with just a few lines of code you can implement an application that sends/receives data with all the benefits of SRT technology: security and reliability, while keeping latency low.
+The purpose of srtgo is easing the adoption of SRT transport technology. Using Go, with just a few lines of code you can implement an application that sends/receives data with all the benefits of SRT technology: security and reliability, while keeping latency low.
 
 ## Is this a new implementation of SRT?
-No! We are just exposing the great work done by the community with [SRT project]((https://github.com/Haivision/srt) as a golang library. All the functionality and implementation still resides on SRT official project.
+No! We are just exposing the great work done by the community in the [SRT project]((https://github.com/Haivision/srt) as a golang library. All the functionality and implementation still resides in the official SRT project.
 
 
 # Features supported
@@ -34,13 +34,15 @@ func main() {
     options := make(map[string]string)
     options["transtype"] = "file"
 
-	sck := srtgo.NewSrtSocket("0.0.0.0", 8090, options)
-	sck.Listen(1)
+    sck := srtgo.NewSrtSocket("0.0.0.0", 8090, options)
+    defer sck.Close()
+    sck.Listen(1)
     s, _ := sck.Accept()
+    defer s.Close()
 
-    buff := make([]byte, 2048)
+    buf := make([]byte, 2048)
     for {
-        n, _ := s.Read(buff)
+        n, _ := s.Read(buf)
         if n == 0 {
             break
         }


### PR DESCRIPTION
Reword the readme a little bit. Avoid leaking epoll descriptors in the example.