### PR TITLE
check and handle epoll-errors, use direction-specific epoll-handles

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ type SrtSockConnected struct{}
 type SrtConnectionRejected struct{}
 type SrtConnectTimeout struct{}
 type SrtSocketClosed struct{}
+type SrtEpollTimeout struct{}
 
 func (m *SrtInvalidSock) Error() string {
 	return "Socket u indicates no valid socket ID"
@@ -28,5 +29,17 @@ func (m *SrtConnectTimeout) Error() string {
 }
 
 func (m *SrtSocketClosed) Error() string {
-	return "The socket u has been closed while the function was blocking the call"
+	return "The socket has been closed"
+}
+
+func (m *SrtEpollTimeout) Error() string {
+	return "Operation has timed out"
+}
+
+func (m *SrtEpollTimeout) Timeout() bool {
+	return true
+}
+
+func (m *SrtEpollTimeout) Temporary() bool {
+	return true
 }


### PR DESCRIPTION
The current epoll_wait calls never check for error and also we currently always subscribe to in and out which almost certainly breaks epoll for bidirectional sockets.

This patch replaces the epoll_wait calls with epoll_uwait and always checks the events for error. It also changes the epoll ids to be separate for input/output and just waits on the relevant id for each operation.

The only small  api-behaviour change is that now non-blocking operations return an error on timeout instead of nil. This can be used to distinguish timeout from success. The timeout error implements Timeout() and Temporary()
The change will almost certainly break nothing because previously non-blocking wasn't working anyway and with a default timeout of -1 the timeout has to be set explicitely.