### PR TITLE
Feature/pass polltimeout as duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Go bindings for [SRT](https://github.com/Haivision/srt) (Secure Reliable Transpo
 The purpose of srtgo is easing the adoption of SRT transport technology. Using Go, with just a few lines of code you can implement an application that sends/receives data with all the benefits of SRT technology: security and reliability, while keeping latency low.
 
 ## Is this a new implementation of SRT?
-No! We are just exposing the great work done by the community in the [SRT project]((https://github.com/Haivision/srt) as a golang library. All the functionality and implementation still resides in the official SRT project.
+No! We are just exposing the great work done by the community in the [SRT project](https://github.com/Haivision/srt) as a golang library. All the functionality and implementation still resides in the official SRT project.
 
 
 # Features supported

--- a/srtgo.go
+++ b/srtgo.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	gopointer "github.com/mattn/go-pointer"
@@ -344,16 +345,16 @@ func (s SrtSocket) PacketSize() int {
 	return s.pktSize
 }
 
-// PollTimeout - Return polling max time, in milliseconds, for connect/read/write operations.
+// PollTimeout - Return polling max time, for connect/read/write operations.
 // Only applied when socket is in non-blocking mode.
-func (s SrtSocket) PollTimeout() int64 {
-	return s.pollTimeout
+func (s SrtSocket) PollTimeout() time.Duration {
+	return time.Duration(s.pollTimeout) * time.Millisecond
 }
 
-// SetPollTimeout - Sets polling max time, in milliseconds, for connect/read/write operations.
+// SetPollTimeout - Sets polling max time, for connect/read/write operations.
 // Only applied when socket is in non-blocking mode.
-func (s *SrtSocket) SetPollTimeout(pollTimeout int64) {
-	s.pollTimeout = pollTimeout
+func (s *SrtSocket) SetPollTimeout(pollTimeout time.Duration) {
+	s.pollTimeout = pollTimeout.Milliseconds()
 }
 
 // Close the SRT socket


### PR DESCRIPTION
A duration is a bit easier to work with as the user doesn't have to worry about the precision required by the call.

Also tiny readme fix