### PR TITLE
Full errno handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,15 @@
 package srtgo
 
+/*
+#cgo LDFLAGS: -lsrt
+#include <srt/srt.h>
+*/
+import "C"
+import (
+	"strconv"
+	"syscall"
+)
+
 type SrtInvalidSock struct{}
 type SrtRendezvousUnbound struct{}
 type SrtSockConnected struct{}
@@ -42,4 +52,191 @@ func (m *SrtEpollTimeout) Timeout() bool {
 
 func (m *SrtEpollTimeout) Temporary() bool {
 	return true
+}
+
+//MUST be called from same OS thread that generated the error (i.e.: use runtime.LockOSThread())
+func srtGetAndClearError() error {
+	defer C.srt_clearlasterror()
+	eSysErrno := C.int(0)
+	errno := C.srt_getlasterror(&eSysErrno)
+	srterr := SRTErrno(errno)
+	if eSysErrno != 0 {
+		return srterr.wrapSysErr(syscall.Errno(eSysErrno))
+	}
+	return srterr
+}
+
+//Based of off golang errno handling: https://cs.opensource.google/go/go/+/refs/tags/go1.16.6:src/syscall/syscall_unix.go;l=114
+type SRTErrno int
+
+func (e SRTErrno) Error() string {
+	//Workaround for unknown being -1
+	if e == Unknown {
+		return "Internal error when setting the right error code"
+	}
+	if 0 <= int(e) && int(e) < len(srterrors) {
+		s := srterrors[e]
+		if s != "" {
+			return s
+		}
+	}
+	return "srterrno: " + strconv.Itoa(int(e))
+}
+
+func (e SRTErrno) Is(target error) bool {
+	//for backwards compat
+	switch target.(type) {
+	case *SrtInvalidSock:
+		return e == EInvSock
+	case *SrtRendezvousUnbound:
+		return e == ERdvUnbound
+	case *SrtSockConnected:
+		return e == EConnSock
+	case *SrtConnectionRejected:
+		return e == EConnRej
+	case *SrtConnectTimeout:
+		return e == ETimeout
+	case *SrtSocketClosed:
+		return e == ESClosed
+	}
+	return false
+}
+
+func (e SRTErrno) Temporary() bool {
+	return e == EAsyncFAIL || e == EAsyncRCV || e == EAsyncSND || e == ECongest || e == ETimeout
+}
+
+func (e SRTErrno) Timeout() bool {
+	return e == ETimeout
+}
+
+func (e SRTErrno) wrapSysErr(errno syscall.Errno) error {
+	return &srtErrnoSysErrnoWrapped{
+		e:    e,
+		eSys: errno,
+	}
+}
+
+type srtErrnoSysErrnoWrapped struct {
+	e    SRTErrno
+	eSys syscall.Errno
+}
+
+func (e *srtErrnoSysErrnoWrapped) Error() string {
+	return e.e.Error()
+}
+
+func (e *srtErrnoSysErrnoWrapped) Is(target error) bool {
+	return e.e.Is(target)
+}
+
+func (e *srtErrnoSysErrnoWrapped) Temporary() bool {
+	return e.e.Temporary()
+}
+
+func (e *srtErrnoSysErrnoWrapped) Timeout() bool {
+	return e.e.Timeout()
+}
+
+func (e *srtErrnoSysErrnoWrapped) Unwrap() error {
+	return error(e.eSys)
+}
+
+//Shadows SRT_ERRNO srtcore/srt.h line 490+
+const (
+	Unknown = SRTErrno(C.SRT_EUNKNOWN)
+	Success = SRTErrno(C.SRT_SUCCESS)
+	//Major: SETUP
+	EConnSetup = SRTErrno(C.SRT_ECONNSETUP)
+	ENoServer  = SRTErrno(C.SRT_ENOSERVER)
+	EConnRej   = SRTErrno(C.SRT_ECONNREJ)
+	ESockFail  = SRTErrno(C.SRT_ESOCKFAIL)
+	ESecFail   = SRTErrno(C.SRT_ESECFAIL)
+	ESClosed   = SRTErrno(C.SRT_ESCLOSED)
+	//Major: CONNECTION
+	EConnFail = SRTErrno(C.SRT_ECONNFAIL)
+	EConnLost = SRTErrno(C.SRT_ECONNLOST)
+	ENoConn   = SRTErrno(C.SRT_ENOCONN)
+	//Major: SYSTEMRES
+	EResource = SRTErrno(C.SRT_ERESOURCE)
+	EThread   = SRTErrno(C.SRT_ETHREAD)
+	EnoBuf    = SRTErrno(C.SRT_ENOBUF)
+	ESysObj   = SRTErrno(C.SRT_ESYSOBJ)
+	//Major: FILESYSTEM
+	EFile     = SRTErrno(C.SRT_EFILE)
+	EInvRdOff = SRTErrno(C.SRT_EINVRDOFF)
+	ERdPerm   = SRTErrno(C.SRT_ERDPERM)
+	EInvWrOff = SRTErrno(C.SRT_EINVWROFF)
+	EWrPerm   = SRTErrno(C.SRT_EWRPERM)
+	//Major: NOTSUP
+	EInvOp          = SRTErrno(C.SRT_EINVOP)
+	EBoundSock      = SRTErrno(C.SRT_EBOUNDSOCK)
+	EConnSock       = SRTErrno(C.SRT_ECONNSOCK)
+	EInvParam       = SRTErrno(C.SRT_EINVPARAM)
+	EInvSock        = SRTErrno(C.SRT_EINVSOCK)
+	EUnboundSock    = SRTErrno(C.SRT_EUNBOUNDSOCK)
+	ENoListen       = SRTErrno(C.SRT_ENOLISTEN)
+	ERdvNoServ      = SRTErrno(C.SRT_ERDVNOSERV)
+	ERdvUnbound     = SRTErrno(C.SRT_ERDVUNBOUND)
+	EInvalMsgAPI    = SRTErrno(C.SRT_EINVALMSGAPI)
+	EInvalBufferAPI = SRTErrno(C.SRT_EINVALBUFFERAPI)
+	EDupListen      = SRTErrno(C.SRT_EDUPLISTEN)
+	ELargeMsg       = SRTErrno(C.SRT_ELARGEMSG)
+	EInvPollID      = SRTErrno(C.SRT_EINVPOLLID)
+	EPollEmpty      = SRTErrno(C.SRT_EPOLLEMPTY)
+	//EBindConflict   = SRTErrno(C.SRT_EBINDCONFLICT)
+	//Major: AGAIN
+	EAsyncFAIL = SRTErrno(C.SRT_EASYNCFAIL)
+	EAsyncSND  = SRTErrno(C.SRT_EASYNCSND)
+	EAsyncRCV  = SRTErrno(C.SRT_EASYNCRCV)
+	ETimeout   = SRTErrno(C.SRT_ETIMEOUT)
+	ECongest   = SRTErrno(C.SRT_ECONGEST)
+	//Major: PEERERROR
+	EPeer = SRTErrno(C.SRT_EPEERERR)
+)
+
+//Unknown cannot be here since it would have a negative index!
+//Error strings taken from: https://github.com/Haivision/srt/blob/master/docs/API/API-functions.md
+var srterrors = [...]string{
+	Success:         "The value set when the last error was cleared and no error has occurred since then",
+	EConnSetup:      "General setup error resulting from internal system state",
+	ENoServer:       "Connection timed out while attempting to connect to the remote address",
+	EConnRej:        "Connection has been rejected",
+	ESockFail:       "An error occurred when trying to call a system function on an internally used UDP socket",
+	ESecFail:        "A possible tampering with the handshake packets was detected, or encryption request wasn't properly fulfilled.",
+	ESClosed:        "A socket that was vital for an operation called in blocking mode has been closed during the operation",
+	EConnFail:       "General connection failure of unknown details",
+	EConnLost:       "The socket was properly connected, but the connection has been broken",
+	ENoConn:         "The socket is not connected",
+	EResource:       "System or standard library error reported unexpectedly for unknown purpose",
+	EThread:         "System was unable to spawn a new thread when requried",
+	EnoBuf:          "System was unable to allocate memory for buffers",
+	ESysObj:         "System was unable to allocate system specific objects",
+	EFile:           "General filesystem error (for functions operating with file transmission)",
+	EInvRdOff:       "Failure when trying to read from a given position in the file",
+	ERdPerm:         "Read permission was denied when trying to read from file",
+	EInvWrOff:       "Failed to set position in the written file",
+	EWrPerm:         "Write permission was denied when trying to write to a file",
+	EInvOp:          "Invalid operation performed for the current state of a socket",
+	EBoundSock:      "The socket is currently bound and the required operation cannot be performed in this state",
+	EConnSock:       "The socket is currently connected and therefore performing the required operation is not possible",
+	EInvParam:       "Call parameters for API functions have some requirements that were not satisfied",
+	EInvSock:        "The API function required an ID of an entity (socket or group) and it was invalid",
+	EUnboundSock:    "The operation to be performed on a socket requires that it first be explicitly bound",
+	ENoListen:       "The socket passed for the operation is required to be in the listen state",
+	ERdvNoServ:      "The required operation cannot be performed when the socket is set to rendezvous mode",
+	ERdvUnbound:     "An attempt was made to connect to a socket set to rendezvous mode that was not first bound",
+	EInvalMsgAPI:    "The function was used incorrectly in the message API",
+	EInvalBufferAPI: "The function was used incorrectly in the stream (buffer) API",
+	EDupListen:      "The port tried to be bound for listening is already busy",
+	ELargeMsg:       "Size exceeded",
+	EInvPollID:      "The epoll ID passed to an epoll function is invalid",
+	EPollEmpty:      "The epoll container currently has no subscribed sockets",
+	//EBindConflict:   "SRT_EBINDCONFLICT",
+	EAsyncFAIL: "General asynchronous failure (not in use currently)",
+	EAsyncSND:  "Sending operation is not ready to perform",
+	EAsyncRCV:  "Receiving operation is not ready to perform",
+	ETimeout:   "The operation timed out",
+	ECongest:   "With SRTO_TSBPDMODE and SRTO_TLPKTDROP set to true, some packets were dropped by sender",
+	EPeer:      "Receiver peer is writing to a file that the agent is sending",
 }

--- a/srtgo.go
+++ b/srtgo.go
@@ -177,6 +177,8 @@ func (s SrtSocket) GetSocket() C.int {
 // may be allowed to wait until they are accepted (excessive connection requests
 // are rejected in advance)
 func (s SrtSocket) Listen(backlog int) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	nbacklog := C.int(backlog)
 
 	sa, salen, err := CreateAddrInet(s.host, s.port)
@@ -187,13 +189,13 @@ func (s SrtSocket) Listen(backlog int) error {
 	res := C.srt_bind(s.socket, sa, C.int(salen))
 	if res == SRT_ERROR {
 		C.srt_close(s.socket)
-		return fmt.Errorf("Error in srt_bind: %v", C.GoString(C.srt_getlasterror_str()))
+		return fmt.Errorf("Error in srt_bind: %w", srtGetAndClearError())
 	}
 
 	res = C.srt_listen(s.socket, nbacklog)
 	if res == SRT_ERROR {
 		C.srt_close(s.socket)
-		return fmt.Errorf("Error in srt_listen: %v", C.GoString(C.srt_getlasterror_str()))
+		return fmt.Errorf("Error in srt_listen: %w", srtGetAndClearError())
 	}
 
 	err = s.postconfiguration(&s)
@@ -206,6 +208,8 @@ func (s SrtSocket) Listen(backlog int) error {
 
 // Accept an incoming connection
 func (s SrtSocket) Accept() (*SrtSocket, *net.UDPAddr, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if !s.blocking {
 		// Socket readiness for accept is checked by polling on SRT_EPOLL_IN
 		timeoutMs := C.int64_t(s.pollTimeout)
@@ -213,13 +217,13 @@ func (s SrtSocket) Accept() (*SrtSocket, *net.UDPAddr, error) {
 		len := C.int(1)
 		res := C.srt_epoll_uwait(s.epollIn, &fds[0], len, timeoutMs)
 		if res == 0 {
-			return nil, nil, &SrtEpollTimeout{}
+			return nil, nil, srtGetAndClearError()
 		}
 		if res == SRT_ERROR {
 			return nil, nil, fmt.Errorf("srt accept, epoll error: %s", C.GoString(C.srt_getlasterror_str()))
 		}
 		if fds[0].events&C.SRT_EPOLL_ERR > 0 {
-			return nil, nil, &SrtSocketClosed{}
+			return nil, nil, srtGetAndClearError()
 		}
 	}
 
@@ -227,7 +231,7 @@ func (s SrtSocket) Accept() (*SrtSocket, *net.UDPAddr, error) {
 	sclen := C.int(syscall.SizeofSockaddrAny)
 	socket := C.srt_accept(s.socket, (*C.struct_sockaddr)(unsafe.Pointer(&addr)), &sclen)
 	if socket == SRT_INVALID_SOCK {
-		return nil, nil, fmt.Errorf("srt accept, error accepting the connection: %s", C.GoString(C.srt_getlasterror_str()))
+		return nil, nil, fmt.Errorf("srt accept, error accepting the connection: %w", srtGetAndClearError())
 	}
 
 	newSocket, err := newFromSocket(&s, socket)
@@ -243,41 +247,20 @@ func (s SrtSocket) Accept() (*SrtSocket, *net.UDPAddr, error) {
 	return newSocket, udpAddr, nil
 }
 
-func errcodeToError(errorcode C.int) error {
-	switch errorcode {
-	case C.SRT_EINVSOCK:
-		return &SrtInvalidSock{}
-	case C.SRT_ERDVUNBOUND:
-		return &SrtRendezvousUnbound{}
-	case C.SRT_ECONNSOCK:
-		return &SrtSockConnected{}
-	case C.SRT_ECONNREJ:
-		return &SrtConnectionRejected{}
-	case C.SRT_ENOSERVER:
-		return &SrtConnectTimeout{}
-	case C.SRT_ESCLOSED:
-		return &SrtSocketClosed{}
-	default:
-		return fmt.Errorf("unknown error")
-	}
-}
-
 // Connect to a remote endpoint
 func (s SrtSocket) Connect() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	sa, salen, err := CreateAddrInet(s.host, s.port)
 	if err != nil {
 		return err
 	}
 
-	runtime.LockOSThread()
 	res := C.srt_connect(s.socket, sa, C.int(salen))
 	if res == SRT_ERROR {
 		C.srt_close(s.socket)
-		srt_errno := C.srt_getlasterror(nil)
-		runtime.UnlockOSThread()
-		return errcodeToError(srt_errno)
+		return srtGetAndClearError()
 	}
-	runtime.UnlockOSThread()
 
 	if !s.blocking {
 		// Socket readiness for connection is checked by polling SRT_EPOLL_OUT.
@@ -293,7 +276,7 @@ func (s SrtSocket) Connect() error {
 			if state != C.SRTS_CONNECTED {
 				return fmt.Errorf("srt connect, connection failed %d", state)
 			}
-			return fmt.Errorf("srt connect, epoll error: %s", C.GoString(C.srt_getlasterror_str()))
+			return fmt.Errorf("srt connect, epoll error: %w", srtGetAndClearError())
 		}
 		if fds[0].events&C.SRT_EPOLL_ERR > 0 {
 			return &SrtSocketClosed{}
@@ -310,6 +293,8 @@ func (s SrtSocket) Connect() error {
 
 // Read data from the SRT socket
 func (s SrtSocket) Read(b []byte) (n int, err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if !s.blocking {
 		timeoutMs := C.int64_t(s.pollTimeout)
 		fds := [1]C.SRT_EPOLL_EVENT{}
@@ -319,16 +304,16 @@ func (s SrtSocket) Read(b []byte) (n int, err error) {
 			return 0, &SrtEpollTimeout{}
 		}
 		if res == SRT_ERROR {
-			return 0, fmt.Errorf("error in read:epoll %s", C.GoString(C.srt_getlasterror_str()))
+			return 0, fmt.Errorf("error in read:epoll %w", srtGetAndClearError())
 		}
 		if fds[0].events&C.SRT_EPOLL_ERR > 0 {
-			return 0, &SrtSocketClosed{}
+			return 0, srtGetAndClearError()
 		}
 	}
 
 	res := C.srt_recvmsg2(s.socket, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)), nil)
 	if res == SRT_ERROR {
-		return 0, fmt.Errorf("error in read::recv %s", C.GoString(C.srt_getlasterror_str()))
+		return 0, fmt.Errorf("error in read:srt_recvmsg2 %w", srtGetAndClearError())
 	}
 
 	return int(res), nil
@@ -336,6 +321,8 @@ func (s SrtSocket) Read(b []byte) (n int, err error) {
 
 // Write data to the SRT socket
 func (s SrtSocket) Write(b []byte) (n int, err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if !s.blocking {
 		timeoutMs := C.int64_t(s.pollTimeout)
 		fds := [1]C.SRT_EPOLL_EVENT{}
@@ -345,7 +332,7 @@ func (s SrtSocket) Write(b []byte) (n int, err error) {
 			return 0, &SrtEpollTimeout{}
 		}
 		if res == SRT_ERROR {
-			return 0, fmt.Errorf("error in write:epoll %s", C.GoString(C.srt_getlasterror_str()))
+			return 0, fmt.Errorf("error in write:epoll %w", srtGetAndClearError())
 		}
 		if fds[0].events&C.SRT_EPOLL_ERR > 0 {
 			return 0, &SrtSocketClosed{}
@@ -354,7 +341,7 @@ func (s SrtSocket) Write(b []byte) (n int, err error) {
 
 	res := C.srt_sendmsg2(s.socket, (*C.char)(unsafe.Pointer(&b[0])), C.int(len(b)), nil)
 	if res == SRT_ERROR {
-		return 0, fmt.Errorf("error in write:srt_sendmsg2 %s", C.GoString(C.srt_getlasterror_str()))
+		return 0, fmt.Errorf("error in write:srt_sendmsg2 %w", srtGetAndClearError())
 	}
 
 	return int(res), nil
@@ -362,10 +349,12 @@ func (s SrtSocket) Write(b []byte) (n int, err error) {
 
 // Stats - Retrieve stats from the SRT socket
 func (s SrtSocket) Stats() (*SrtStats, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	var stats C.SRT_TRACEBSTATS = C.SRT_TRACEBSTATS{}
 	var b C.int = 1
 	if C.srt_bstats(s.socket, &stats, b) == SRT_ERROR {
-		return nil, fmt.Errorf("Error getting stats, %s", C.GoString(C.srt_getlasterror_str()))
+		return nil, fmt.Errorf("Error getting stats, %w", srtGetAndClearError())
 	}
 
 	return newSrtStats(&stats), nil
@@ -460,7 +449,7 @@ func srtConnectCBWrapper(arg unsafe.Pointer, socket C.SRTSOCKET, errcode C.int, 
 	s.socket = socket
 	udpAddr, _ := udpAddrFromSockaddr((*syscall.RawSockaddrAny)(unsafe.Pointer(peeraddr)))
 
-	userCB(s, errcodeToError(errcode), udpAddr, int(token))
+	userCB(s, SRTErrno(errcode), udpAddr, int(token))
 }
 
 // SetConnectCallback - set a function to be called after a socket or connection in a group has failed
@@ -598,24 +587,29 @@ func (s SrtSocket) SetSockOptString(opt int, value string) error {
 }
 
 func (s SrtSocket) setSockOpt(opt int, data unsafe.Pointer, size int) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	res := C.srt_setsockopt(s.socket, 0, C.SRT_SOCKOPT(opt), data, C.int(size))
 	if res == -1 {
-		return fmt.Errorf("Error calling srt_setsockopt %v", C.GoString(C.srt_getlasterror_str()))
+		return fmt.Errorf("Error calling srt_setsockopt %w", srtGetAndClearError())
 	}
-
 	return nil
 }
 
 func (s SrtSocket) getSockOpt(opt int, data unsafe.Pointer, size *int) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	res := C.srt_getsockopt(s.socket, 0, C.SRT_SOCKOPT(opt), data, (*C.int)(unsafe.Pointer(size)))
 	if res == -1 {
-		return fmt.Errorf("Error calling srt_getsockopt %v", C.GoString(C.srt_getlasterror_str()))
+		return fmt.Errorf("Error calling srt_getsockopt %w", srtGetAndClearError())
 	}
 
 	return nil
 }
 
 func (s SrtSocket) preconfiguration() (int, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	var blocking C.int
 	if s.blocking {
 		blocking = C.int(1)
@@ -624,7 +618,7 @@ func (s SrtSocket) preconfiguration() (int, error) {
 	}
 	result := C.srt_setsockopt(s.socket, 0, C.SRTO_RCVSYN, unsafe.Pointer(&blocking), C.int(unsafe.Sizeof(blocking)))
 	if result == -1 {
-		return ModeFailure, fmt.Errorf("could not set SRTO_RCVSYN flag")
+		return ModeFailure, fmt.Errorf("could not set SRTO_RCVSYN flag: %w", srtGetAndClearError())
 	}
 
 	var mode int
@@ -655,21 +649,25 @@ func (s SrtSocket) preconfiguration() (int, error) {
 	if linger, ok := s.options["linger"]; ok {
 		li, err := strconv.Atoi(linger)
 		if err == nil {
-			setSocketLingerOption(s.socket, int32(li))
+			if err := setSocketLingerOption(s.socket, int32(li)); err != nil {
+				return ModeFailure, fmt.Errorf("could not set LINGER option %w", err)
+			}
 		} else {
-			return ModeFailure, fmt.Errorf("could not set LINGER option")
+			return ModeFailure, fmt.Errorf("could not set LINGER option %w", err)
 		}
 	}
 
 	err := setSocketOptions(s.socket, bindingPre, s.options)
 	if err != nil {
-		return ModeFailure, fmt.Errorf("Error setting socket options")
+		return ModeFailure, fmt.Errorf("Error setting socket options: %w", err)
 	}
 
 	return mode, nil
 }
 
 func (s SrtSocket) postconfiguration(sck *SrtSocket) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	var blocking C.int
 	if s.blocking {
 		blocking = 1
@@ -679,12 +677,12 @@ func (s SrtSocket) postconfiguration(sck *SrtSocket) error {
 
 	res := C.srt_setsockopt(sck.socket, 0, C.SRTO_SNDSYN, unsafe.Pointer(&blocking), C.int(unsafe.Sizeof(blocking)))
 	if res == -1 {
-		return fmt.Errorf("Error in postconfiguration setting SRTO_SNDSYN")
+		return fmt.Errorf("Error in postconfiguration setting SRTO_SNDSYN: %w", srtGetAndClearError())
 	}
 
 	res = C.srt_setsockopt(sck.socket, 0, C.SRTO_RCVSYN, unsafe.Pointer(&blocking), C.int(unsafe.Sizeof(blocking)))
 	if res == -1 {
-		return fmt.Errorf("Error in postconfiguration setting SRTO_RCVSYN")
+		return fmt.Errorf("Error in postconfiguration setting SRTO_RCVSYN: %w", srtGetAndClearError())
 	}
 
 	err := setSocketOptions(sck.socket, bindingPost, s.options)

--- a/srtsocketoptions.go
+++ b/srtsocketoptions.go
@@ -5,7 +5,7 @@ package srtgo
 import "C"
 
 import (
-	"log"
+	"fmt"
 	"strconv"
 	"syscall"
 	"unsafe"
@@ -54,7 +54,7 @@ const (
 	SRTO_ENFORCEDENCRYPTION = C.SRTO_ENFORCEDENCRYPTION
 	SRTO_PEERIDLETIMEO      = C.SRTO_PEERIDLETIMEO
 	SRTO_PACKETFILTER       = C.SRTO_PACKETFILTER
-	SRTO_STATE		= C.SRTO_STATE
+	SRTO_STATE              = C.SRTO_STATE
 )
 
 type socketOption struct {
@@ -123,7 +123,7 @@ func setSocketOptions(s C.int, binding int, options map[string]string) error {
 					if err == nil {
 						result := C.srt_setsockflag(s, C.SRT_SOCKOPT(so.option), unsafe.Pointer(&v32), C.int32_t(unsafe.Sizeof(v32)))
 						if result == -1 {
-							log.Printf("Warning - Error setting option %s to %s, %v", so.name, val, C.GoString(C.srt_getlasterror_str()))
+							return fmt.Errorf("warning - error setting option %s to %s, %w", so.name, val, srtGetAndClearError())
 						}
 					}
 				} else if so.dataType == tInteger64 {
@@ -131,7 +131,7 @@ func setSocketOptions(s C.int, binding int, options map[string]string) error {
 					if err == nil {
 						result := C.srt_setsockflag(s, C.SRT_SOCKOPT(so.option), unsafe.Pointer(&v), C.int32_t(unsafe.Sizeof(v)))
 						if result == -1 {
-							log.Printf("Warning - Error setting option %s to %s, %v", so.name, val, C.GoString(C.srt_getlasterror_str()))
+							return fmt.Errorf("warning - error setting option %s to %s, %w", so.name, val, srtGetAndClearError())
 						}
 					}
 				} else if so.dataType == tString {
@@ -139,7 +139,7 @@ func setSocketOptions(s C.int, binding int, options map[string]string) error {
 					defer C.free(unsafe.Pointer(sval))
 					result := C.srt_setsockflag(s, C.SRT_SOCKOPT(so.option), unsafe.Pointer(sval), C.int32_t(len(val)))
 					if result == -1 {
-						log.Printf("Warning - Error setting option %s to %s, %v", so.name, val, C.GoString(C.srt_getlasterror_str()))
+						return fmt.Errorf("warning - error setting option %s to %s, %w", so.name, val, srtGetAndClearError())
 					}
 
 				} else if so.dataType == tBoolean {
@@ -152,7 +152,7 @@ func setSocketOptions(s C.int, binding int, options map[string]string) error {
 						result = C.srt_setsockflag(s, C.SRT_SOCKOPT(so.option), unsafe.Pointer(&v), C.int32_t(unsafe.Sizeof(v)))
 					}
 					if result == -1 {
-						log.Printf("Warning - Error setting option %s to %s, %v", so.name, val, C.GoString(C.srt_getlasterror_str()))
+						return fmt.Errorf("warning - error setting option %s to %s, %w", so.name, val, srtGetAndClearError())
 					}
 				} else if so.dataType == tTransType {
 					var result C.int
@@ -164,7 +164,7 @@ func setSocketOptions(s C.int, binding int, options map[string]string) error {
 						result = C.srt_setsockflag(s, C.SRT_SOCKOPT(so.option), unsafe.Pointer(&v), C.int32_t(unsafe.Sizeof(v)))
 					}
 					if result == -1 {
-						log.Printf("Warning - Error setting option %s to %s: %v", so.name, val, C.GoString(C.srt_getlasterror_str()))
+						return fmt.Errorf("warning - error setting option %s to %s: %w", so.name, val, srtGetAndClearError())
 					}
 				}
 			}


### PR DESCRIPTION
Handle all SRT_E values and create typed errors that can be checked by
consumers of srtgo library. Based on the runtime syscall.Errno code.
In all functions that can return an srt error value the OS thread is
locked, to make sure golang does not schedule is away from the thread.
This is needed since srt stores it's error value in thread local
storage.