### PR TITLE
Fix Read operation return value must be >= 0

### DIFF
--- a/read.go
+++ b/read.go
@@ -31,6 +31,7 @@ func srtRecvMsg2Impl(u C.SRTSOCKET, buf []byte, msgctrl *C.SRT_MSGCTRL) (n int, 
 			srterror.wrapSysErr(syscall.Errno(syserr))
 		}
 		err = srterror
+		n = 0
 	}
 	return
 }

--- a/write.go
+++ b/write.go
@@ -31,6 +31,7 @@ func srtSendMsg2Impl(u C.SRTSOCKET, buf []byte, msgctrl *C.SRT_MSGCTRL) (n int, 
 			srterror.wrapSysErr(syscall.Errno(syserr))
 		}
 		err = srterror
+		n = 0
 	}
 	return
 }


### PR DESCRIPTION
I noticed that when using the library with bufio I get a segfault when the connection is closed. This is due to the returned value from the Read operation which is negative.
Indeed, bufio is protected against that: https://github.com/golang/go/blob/master/src/bufio/bufio.go#L108
Also, from the Read documentation, n should be 0 <= n <= len(p) (https://github.com/golang/go/blob/master/src/io/io.go#L58)

The modification I have done is really simple, it is just re-assigning n to zero in case of error (negative value)