### PR TITLE
Add alternate srt GO packages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,9 @@ func main() {
 You can find detailed instructions about how to install srtlib in its [README file](https://github.com/Haivision/srt#requirements)
 
 gosrt has been developed with srt 1.4.1 as its main target and has been successfully tested in srt 1.3.4 and above.
+
+# Alternate `srt` GO packages
+
+Although `srtgo` is the official `srt` GO bindings, here's a list of alternate `srt` GO packages:
+
+- [astisrt](https://github.com/asticode/go-astisrt)

--- a/README.md
+++ b/README.md
@@ -66,4 +66,6 @@ gosrt has been developed with srt 1.4.1 as its main target and has been successf
 
 Although `srtgo` is the official `srt` GO bindings, here's a list of alternate `srt` GO packages:
 
+In alphabet order:
 - [astisrt](https://github.com/asticode/go-astisrt)
+- [gosrt](https://github.com/datarhei/gosrt)


### PR DESCRIPTION
Hi,

I've developped an alternate `srt` [GO package](https://github.com/asticode/go-astisrt), and since this is the official GO bindings I would love it to be referenced here.

If you don't feel like it, no worries, you can close this PR 👍 

Cheers