### PR TITLE
use pkg-config

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 
 SRTSOCKET srt_accept_wrapped(SRTSOCKET lsn, struct sockaddr* addr, int* addrlen, int *srterror, int *syserror)

--- a/callback_c.go
+++ b/callback_c.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include "callback.h"
 
 int srtListenCB(void* opaque, SRTSOCKET ns, int hs_version, const struct sockaddr* peeraddr, const char* streamid)

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 */
 import "C"
@@ -54,7 +53,7 @@ func (m *SrtEpollTimeout) Temporary() bool {
 	return true
 }
 
-//MUST be called from same OS thread that generated the error (i.e.: use runtime.LockOSThread())
+// MUST be called from same OS thread that generated the error (i.e.: use runtime.LockOSThread())
 func srtGetAndClearError() error {
 	defer C.srt_clearlasterror()
 	eSysErrno := C.int(0)
@@ -66,7 +65,7 @@ func srtGetAndClearError() error {
 	return srterr
 }
 
-//Based of off golang errno handling: https://cs.opensource.google/go/go/+/refs/tags/go1.16.6:src/syscall/syscall_unix.go;l=114
+// Based of off golang errno handling: https://cs.opensource.google/go/go/+/refs/tags/go1.16.6:src/syscall/syscall_unix.go;l=114
 type SRTErrno int
 
 func (e SRTErrno) Error() string {
@@ -142,7 +141,7 @@ func (e *srtErrnoSysErrnoWrapped) Unwrap() error {
 	return error(e.eSys)
 }
 
-//Shadows SRT_ERRNO srtcore/srt.h line 490+
+// Shadows SRT_ERRNO srtcore/srt.h line 490+
 const (
 	Unknown = SRTErrno(C.SRT_EUNKNOWN)
 	Success = SRTErrno(C.SRT_SUCCESS)
@@ -195,8 +194,8 @@ const (
 	EPeer = SRTErrno(C.SRT_EPEERERR)
 )
 
-//Unknown cannot be here since it would have a negative index!
-//Error strings taken from: https://github.com/Haivision/srt/blob/master/docs/API/API-functions.md
+// Unknown cannot be here since it would have a negative index!
+// Error strings taken from: https://github.com/Haivision/srt/blob/master/docs/API/API-functions.md
 var srterrors = [...]string{
 	Success:         "The value set when the last error was cleared and no error has occurred since then",
 	EConnSetup:      "General setup error resulting from internal system state",

--- a/examples/echo-receiver/main.go
+++ b/examples/echo-receiver/main.go
@@ -1,6 +1,5 @@
 package main
 
-// #cgo LDFLAGS: -lsrt
 // #include <srt/srt.h>
 import "C"
 

--- a/logging.go
+++ b/logging.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 extern void srtLogCB(void* opaque, int level, const char* file, int line, const char* area, const char* message);
 */

--- a/logging_c.go
+++ b/logging_c.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 
 extern void srtLogCBWrapper (void* opaque, int level, char* file, int line, char* area, char* message);

--- a/poll.go
+++ b/poll.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 */
 import "C"
@@ -25,14 +24,14 @@ const (
 )
 
 /*
-	pollDesc contains the polling state for the associated SrtSocket
-	closing: socket is closing, reject all poll operations
-	pollErr: an error occured on the socket, indicates it's not useable anymore.
-	unblockRd: is used to unblock the poller when the socket becomes ready for io
-	rdState: polling state for read operations
-	rdDeadline: deadline in NS before poll operation times out, -1 means timedout (needs to be cleared), 0 is without timeout
-	rdSeq: sequence number protects against spurious signalling of timeouts when timer is reset.
-	rdTimer: timer used to enforce deadline.
+pollDesc contains the polling state for the associated SrtSocket
+closing: socket is closing, reject all poll operations
+pollErr: an error occured on the socket, indicates it's not useable anymore.
+unblockRd: is used to unblock the poller when the socket becomes ready for io
+rdState: polling state for read operations
+rdDeadline: deadline in NS before poll operation times out, -1 means timedout (needs to be cleared), 0 is without timeout
+rdSeq: sequence number protects against spurious signalling of timeouts when timer is reset.
+rdTimer: timer used to enforce deadline.
 */
 type pollDesc struct {
 	lock       sync.Mutex

--- a/pollserver.go
+++ b/pollserver.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 */
 import "C"

--- a/read.go
+++ b/read.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 
 int srt_recvmsg2_wrapped(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL *mctrl, int *srterror, int *syserror)

--- a/srtgo.go
+++ b/srtgo.go
@@ -1,7 +1,7 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
+#cgo pkg-config: srt
 #include <srt/srt.h>
 #include <srt/access_control.h>
 #include "callback.h"

--- a/srtsocketoptions.go
+++ b/srtsocketoptions.go
@@ -1,6 +1,5 @@
 package srtgo
 
-// #cgo LDFLAGS: -lsrt
 // #include <srt/srt.h>
 import "C"
 

--- a/srtstats.go
+++ b/srtstats.go
@@ -1,6 +1,5 @@
 package srtgo
 
-// #cgo LDFLAGS: -lsrt
 // #include <srt/srt.h>
 import "C"
 

--- a/write.go
+++ b/write.go
@@ -1,7 +1,6 @@
 package srtgo
 
 /*
-#cgo LDFLAGS: -lsrt
 #include <srt/srt.h>
 
 int srt_sendmsg2_wrapped(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL *mctrl, int *srterror, int *syserror)


### PR DESCRIPTION
This makes it easier to link against static compiled versions of srt

The multitude of LDFLAGS declarations is superfluous: once is enough for the package that interacts with the C code.