### PR TITLE
Fix/poll deadline timeout

### DIFF
--- a/read.go
+++ b/read.go
@@ -48,7 +48,9 @@ func (s SrtSocket) Read(b []byte) (n int, err error) {
 		if !errors.Is(err, error(EAsyncRCV)) || s.blocking {
 			return
 		}
-		s.pd.wait(ModeRead)
+		if err = s.pd.wait(ModeRead); err != nil {
+			return
+		}
 		n, err = srtRecvMsg2Impl(s.socket, b, nil)
 	}
 }

--- a/write.go
+++ b/write.go
@@ -49,7 +49,9 @@ func (s SrtSocket) Write(b []byte) (n int, err error) {
 		if !errors.Is(err, error(EAsyncSND)) || s.blocking {
 			return
 		}
-		s.pd.wait(ModeWrite)
+		if err = s.pd.wait(ModeWrite); err != nil {
+			return
+		}
 		n, err = srtSendMsg2Impl(s.socket, b, nil)
 	}
 }


### PR DESCRIPTION
 Fixed a few issues around polling timeouts.
1. When the poll descriptor is created, it is with a duration of 0, which causes the deadline timer to fire right away and that's waiting the next time a deadline is set up.
2. If there is a delay between setting up deadlines, and the timer fired after the `poll.Wait()` had returned, that timer signal is not cleared from the channel and will cause wait to return immediately.
3. The return value from `poll.Wait()` is not checked in the `Read` and `Write` functions, which will cause a Read to hang if there is no data on the socket.