### PR TITLE
fix calling srt_close on the same descriptor twice

### DIFF
--- a/srtgo.go
+++ b/srtgo.go
@@ -279,6 +279,7 @@ func (s *SrtSocket) SetWriteDeadline(deadline time.Time) {
 func (s *SrtSocket) Close() {
 
 	C.srt_close(s.socket)
+	s.socket = SRT_INVALID_SOCK
 	if !s.blocking {
 		s.pd.close()
 	}


### PR DESCRIPTION
If client code calls `Close` on a connection, there's a chance that when `Close` is called in the finalizer, the library will free the socket two times