### PR TITLE
fix race where poll state is changed in unblock and reset

### DIFF
--- a/poll.go
+++ b/poll.go
@@ -257,6 +257,8 @@ func (pd *pollDesc) unblock(mode PollMode, pollerr, ioready bool) {
 }
 
 func (pd *pollDesc) reset(mode PollMode) {
+	pd.lock.Lock()
+	defer pd.lock.Unlock()
 	if mode == ModeRead {
 		pd.rdLock.Lock()
 		pd.rdState = pollDefault


### PR DESCRIPTION
`pollDesc.unblock()`, which modifies either `pd.rdState` or `pd.wrState` is called by the pollserver thread and only locks `pd.lock`.  However, `pd.reset` which is called by read/write operations only locks `pd.wrLock` or `pd.rdLock` leading to a race.