### PR TITLE
Add various fixes for SetDeadline functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- [SA-1463] Return error when trying to create a new socket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog
 
 - [SA-1463] Return error when trying to create a new socket
+- [SA-2074] Add a ReadPacket function

--- a/examples/echo-receiver/main.go
+++ b/examples/echo-receiver/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/haivision/srtgo"
+	srtgo "github.com/SpalkLtd/spalk-srtgo"
 )
 
 var allowedStreamIDs = map[string]bool{

--- a/examples/echo-receiver/main.go
+++ b/examples/echo-receiver/main.go
@@ -55,7 +55,7 @@ func main() {
 	options["latency"] = "300"
 
 	// create and bind socket
-	sck := srtgo.NewSrtSocket("127.0.0.1", 6000, options)
+	sck, _ := srtgo.NewSrtSocket("127.0.0.1", 6000, options)
 
 	// set listen callback
 	sck.SetListenCallback(listenCallback)

--- a/examples/file-receiver/main.go
+++ b/examples/file-receiver/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/haivision/srtgo"
+	srtgo "github.com/SpalkLtd/spalk-srtgo"
 )
 
 func main() {

--- a/examples/file-receiver/main.go
+++ b/examples/file-receiver/main.go
@@ -16,7 +16,7 @@ func main() {
 	port := 8090
 
 	fmt.Printf("(srt://%s:%d) Listening", hostname, port)
-	a := srtgo.NewSrtSocket(hostname, uint16(port), options)
+	a, _ := srtgo.NewSrtSocket(hostname, uint16(port), options)
 	err := a.Listen(2)
 	defer a.Close()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SpalkLtd/spalk-srtgo
 
-go 1.12
+go 1.18
 
 require (
 	github.com/mattn/go-pointer v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/haivision/srtgo
+module github.com/SpalkLtd/spalk-srtgo
 
 go 1.12
 

--- a/poll_test.go
+++ b/poll_test.go
@@ -7,7 +7,7 @@ import (
 func connectLoop(port uint16, semChan chan struct{}) {
 	for {
 		//fmt.Printf("Connecting\n")
-		s := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": "0", "mode": "caller"})
+		s, _ := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": "0", "mode": "caller"})
 		err := s.Connect()
 		if err != nil {
 			continue
@@ -23,7 +23,7 @@ func connectLoop(port uint16, semChan chan struct{}) {
 func benchAccept(blocking string, N int) {
 start:
 	port := randomPort()
-	s := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": blocking, "mode": "listener"})
+	s, _ := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": blocking, "mode": "listener"})
 	if s == nil {
 		goto start
 	}

--- a/rw_test.go
+++ b/rw_test.go
@@ -19,7 +19,7 @@ type tester struct {
 // Creates a connector socket and keeps writing to it
 func (t *tester) send(port uint16) {
 	buf := make([]byte, 1316)
-	sock := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": t.blocking, "mode": "caller", "transtype": "file", "latency": "300"})
+	sock, _ := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": t.blocking, "mode": "caller", "transtype": "file", "latency": "300"})
 	if sock == nil {
 		t.err <- fmt.Errorf("failed to create caller socket")
 		return
@@ -52,7 +52,7 @@ func (t *tester) send(port uint16) {
 
 // Creates a listener socket and keeps reading from it
 func (t *tester) receive(port uint16, iterations int) {
-	sock := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": t.blocking, "mode": "listener", "rcvbuf": "22937600", "transtype": "file", "latency": "300"})
+	sock, _ := NewSrtSocket("127.0.0.1", port, map[string]string{"blocking": t.blocking, "mode": "listener", "rcvbuf": "22937600", "transtype": "file", "latency": "300"})
 	if sock == nil {
 		t.err <- fmt.Errorf("failed to create listener socket")
 		return

--- a/srtgo.go
+++ b/srtgo.go
@@ -84,7 +84,7 @@ func NewSrtSocket(host string, port uint16, options map[string]string) (*SrtSock
 
 	s.socket = C.srt_create_socket()
 	if s.socket == SRT_INVALID_SOCK {
-		return nil, errors.New("Error creating srt socket: SRT_INVALID_SOCK")
+		return nil, fmt.Errorf("Error creating srt socket: SRT_INVALID_SOCK, %w", srtGetAndClearError())
 	}
 
 	s.host = host

--- a/srtgo.go
+++ b/srtgo.go
@@ -79,12 +79,12 @@ func CleanupSRT() {
 }
 
 // NewSrtSocket - Create a new SRT Socket
-func NewSrtSocket(host string, port uint16, options map[string]string) *SrtSocket {
+func NewSrtSocket(host string, port uint16, options map[string]string) (*SrtSocket, error) {
 	s := new(SrtSocket)
 
 	s.socket = C.srt_create_socket()
 	if s.socket == SRT_INVALID_SOCK {
-		return nil
+		return nil, errors.New("Error creating srt socket: SRT_INVALID_SOCK")
 	}
 
 	s.host = host
@@ -126,10 +126,10 @@ func NewSrtSocket(host string, port uint16, options map[string]string) *SrtSocke
 	var err error
 	s.mode, err = s.preconfiguration()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("Error handling preconfiguration when creatig an srt socket: %w", err)
 	}
 
-	return s
+	return s, nil
 }
 
 func newFromSocket(acceptSocket *SrtSocket, socket C.SRTSOCKET) (*SrtSocket, error) {

--- a/srtgo_test.go
+++ b/srtgo_test.go
@@ -17,7 +17,7 @@ func randomPort() uint16 {
 
 func TestNewSocket(t *testing.T) {
 	options := make(map[string]string)
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket")
@@ -27,7 +27,7 @@ func TestNewSocket(t *testing.T) {
 func TestNewSocketBlocking(t *testing.T) {
 	options := make(map[string]string)
 	options["blocking"] = "true"
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket")
@@ -37,7 +37,7 @@ func TestNewSocketBlocking(t *testing.T) {
 func TestNewSocketLinger(t *testing.T) {
 	options := make(map[string]string)
 	options["linger"] = "1000"
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket with linger")
@@ -56,7 +56,7 @@ func TestNewSocketLinger(t *testing.T) {
 func TestNewSocketWithTransType(t *testing.T) {
 	options := make(map[string]string)
 	options["transtype"] = "3"
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket")
@@ -66,7 +66,7 @@ func TestNewSocketWithTransType(t *testing.T) {
 func TestNewSocketWithParameters(t *testing.T) {
 	options := make(map[string]string)
 	options["pbkeylen"] = "32"
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket")
@@ -76,7 +76,7 @@ func TestNewSocketWithParameters(t *testing.T) {
 func TestNewSocketWithInt64Param(t *testing.T) {
 	options := make(map[string]string)
 	options["maxbw"] = "300000"
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket")
@@ -86,7 +86,7 @@ func TestNewSocketWithInt64Param(t *testing.T) {
 func TestNewSocketWithBoolParam(t *testing.T) {
 	options := make(map[string]string)
 	options["enforcedencryption"] = "0"
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket")
@@ -96,7 +96,7 @@ func TestNewSocketWithBoolParam(t *testing.T) {
 func TestNewSocketWithStringParam(t *testing.T) {
 	options := make(map[string]string)
 	options["passphrase"] = "11111111111"
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	if a == nil {
 		t.Error("Could not create a srt socket")
@@ -110,7 +110,7 @@ func TestListen(t *testing.T) {
 	options["blocking"] = "0"
 	options["transtype"] = "file"
 
-	a := NewSrtSocket("0.0.0.0", 8090, options)
+	a, _ := NewSrtSocket("0.0.0.0", 8090, options)
 	err := a.Listen(2)
 	if err != nil {
 		t.Error("Error on testListen")
@@ -119,10 +119,11 @@ func TestListen(t *testing.T) {
 
 func AcceptHelper(numSockets int, port uint16, options map[string]string, t *testing.T) {
 	listening := make(chan struct{})
-	listener := NewSrtSocket("localhost", port, options)
+	listener, _ := NewSrtSocket("localhost", port, options)
 	var connectors []*SrtSocket
 	for i := 0; i < numSockets; i++ {
-		connectors = append(connectors, NewSrtSocket("localhost", port, options))
+		sock, _ := NewSrtSocket("localhost", port, options)
+		connectors = append(connectors, sock)
 	}
 	wg := sync.WaitGroup{}
 	timer := time.AfterFunc(time.Second, func() {
@@ -205,7 +206,7 @@ func TestMultipleAcceptBlocking(t *testing.T) {
 func TestSetSockOptInt(t *testing.T) {
 	InitSRT()
 	options := make(map[string]string)
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	expected := 200
 	err := a.SetSockOptInt(SRTO_LATENCY, expected)
@@ -225,7 +226,7 @@ func TestSetSockOptInt(t *testing.T) {
 func TestSetSockOptString(t *testing.T) {
 	InitSRT()
 	options := make(map[string]string)
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	expected := "123"
 	err := a.SetSockOptString(SRTO_STREAMID, expected)
@@ -245,7 +246,7 @@ func TestSetSockOptString(t *testing.T) {
 func TestSetSockOptBool(t *testing.T) {
 	InitSRT()
 	options := make(map[string]string)
-	a := NewSrtSocket("localhost", 8090, options)
+	a, _ := NewSrtSocket("localhost", 8090, options)
 
 	expected := true
 	err := a.SetSockOptBool(SRTO_MESSAGEAPI, expected)

--- a/srtsocketoptions.go
+++ b/srtsocketoptions.go
@@ -5,7 +5,6 @@ package srtgo
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"syscall"
@@ -111,7 +110,7 @@ func setSocketLingerOption(s C.int, li int32) error {
 	}
 	res := C.srt_setsockopt(s, bindingPre, C.SRTO_LINGER, unsafe.Pointer(&lin), C.int(unsafe.Sizeof(lin)))
 	if res == SRT_ERROR {
-		return errors.New("failed to set linger")
+		return fmt.Errorf("failed to set linger: %w", srtGetAndClearError())
 	}
 	return nil
 }


### PR DESCRIPTION
As per `https://github.com/Haivision/srtgo/pull/63` (and `https://github.com/Haivision/srtgo/pull/58`, but the fixes aren't as nice)...

_SetDeadline has a few silly mistakes:_

_Issue 1) When the poll descriptor is created, it is with a duration of 0, which causes the deadline timer to fire right away and that's waiting the next time a deadline is set up.
Issue 2) If there is a delay between setting up deadlines, and the timer fired after the poll.Wait() had returned, that timer signal is not cleared from the channel and will cause wait to return immediately.
Issue 3) The return value from poll.Wait() is not checked in the Read and Write functions, which will cause a Read to hang if there is no data on the socket_

Example of 1:
```
socket, socketCreateErr = srtgo.NewSrtSocket(s.host, s.port, s.options)

spa.socket.SetWriteDeadline() // Use deadline

err := socket.Connect() // Will return immediately, because the deadline timer fires immediately
```

Example of 3:
```
socket, socketCreateErr = srtgo.NewSrtSocket(s.host, s.port, s.options)
err := socket.Connect()

socket.ReadPacket(srtPacket) // Will wait forever, because there isn't actually a check if the deadline has been met.
```

---

As per my experiments...

Issue 4) `SetWriteDeadline` is currently equivalent to both `SetReadDeadline` and `SetWriteDeadline`, due to a silly mistake.
