### PR TITLE
Windows build and SetDeadline deadlock fixes

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -46,7 +46,7 @@ func (s SrtSocket) Accept() (*SrtSocket, *net.UDPAddr, error) {
 		}
 	}
 	var addr syscall.RawSockaddrAny
-	sclen := C.int(syscall.SizeofSockaddrAny)
+	sclen := C.int(sizeofSockaddrAny)
 	socket, err := srtAcceptImpl(s.socket, (*C.struct_sockaddr)(unsafe.Pointer(&addr)), &sclen)
 	if err != nil {
 		return nil, nil, err

--- a/poll.go
+++ b/poll.go
@@ -239,12 +239,12 @@ func (pd *pollDesc) unblock(mode PollMode, pollerr, ioready bool) {
 		state = &pd.wrState
 		unblockChan = pd.unblockWr
 	}
-	pd.lock.Lock()
-	old := atomic.LoadInt32(state)
+	var old int32
 	if ioready {
-		atomic.StoreInt32(state, pollReady)
+		old = atomic.SwapInt32(state, pollReady)
+	} else {
+		old = atomic.LoadInt32(state)
 	}
-	pd.lock.Unlock()
 	if old == pollWait {
 		//make sure we never block here
 		select {


### PR DESCRIPTION
There are 2 fixes:
1. accept.go can't be compiled under Windows because of missing syscall.SizeofSockaddrAny
2. SetDeadline has deadlock because it calls pd.lock.Lock() at the start and then in unblock it tried to call pd.lock.Lock() again. But mutexes in go are different from posix because Go mutexes cannot be locked again even in the same thread/coroutine. Also, locks in poll.unblock are unnecessary and can be replaced by one SwapInt32 instead of load and store.